### PR TITLE
feat: nginx reverse proxy for backend

### DIFF
--- a/.env
+++ b/.env
@@ -13,3 +13,4 @@ ELECTRS_IMAGE=boltz/electrs:latest
 ESPLORA_IMAGE=boltz/esplora:latest
 OTTERSCAN_IMAGE=otterscan/otterscan:latest
 RIF_RELAY_IMAGE=boltz/rif-relay:latest
+NGINX_IMAGE=nginx:alpine

--- a/data/backend-nginx/default.conf
+++ b/data/backend-nginx/default.conf
@@ -1,0 +1,24 @@
+server {
+    listen 9001;
+    listen [::]:9001;
+    server_name localhost;
+
+    location /v2/ws {
+        proxy_pass http://boltz:9004/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        proxy_pass http://boltz:9001;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/data/backend/boltz.conf
+++ b/data/backend/boltz.conf
@@ -18,6 +18,10 @@ password = "boltz"
   host = "127.0.0.1"
   port = 9003
 
+  [sidecar.ws]
+  host = "0.0.0.0"
+  port = 9004
+
 [[pairs]]
 base = "BTC"
 quote = "BTC"
@@ -104,6 +108,7 @@ maxZeroConfAmount = 40_294_967
   wallet = "regtest"
 
 [rsk]
+networkName = "Anvil"
 providerEndpoint = "http://anvil:8545"
 
 etherSwapAddress = "0x7a2088a1bFc9d81c55368AE168C2C02570cB814F"

--- a/data/boltz-client/boltz.toml
+++ b/data/boltz-client/boltz.toml
@@ -7,7 +7,7 @@ electrumLiquidUrl = "electrs-liquid:19002"
 [BOLTZ]
 # By default the daemon automatically connects to the official Boltz instance for the network LND is on
 # This value is used to override that
-url = "http://boltz:9001"
+url = "http://boltz-nginx:9001"
 
 [DATABASE]
 # Path to the SQLite database file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,6 @@ services:
     image: ${BOLTZ_BACKEND_IMAGE}
     ports:
       - 9000:9000
-      - 9001:9001
     volumes:
       - boltz-data:/root/.boltz
       - lnd2-data:/data/lnd
@@ -126,11 +125,31 @@ services:
       start_period: 0s
     profiles: ["default", "ci"]
 
+  boltz-backend-nginx:
+    hostname: boltz-nginx
+    container_name: boltz-backend-nginx
+    depends_on:
+      boltz-backend:
+        condition: service_healthy
+    restart: always
+    image: ${NGINX_IMAGE}
+    ports:
+      - 9001:9001
+    volumes:
+      - nginx-data:/etc/nginx/conf.d
+    healthcheck:
+      test: [ "CMD-SHELL", "curl http://localhost:9001/version" ]
+      timeout: 1s
+      retries: 10
+      interval: 1s
+      start_period: 0s
+    profiles: ["default", "ci"]
+
   boltz-web-app:
     hostname: web-app
     container_name: boltz-web-app
     depends_on:
-      boltz-backend:
+      boltz-backend-nginx:
         condition: service_healthy
     restart: always
     image: ${BOLTZ_WEBAPP_IMAGE}
@@ -142,7 +161,7 @@ services:
     hostname: boltz-client
     container_name: boltz-client
     depends_on:
-      boltz-backend:
+      boltz-backend-nginx:
         condition: service_healthy
     restart: always
     image: ${BOLTZ_CLIENT_IMAGE}
@@ -489,3 +508,10 @@ volumes:
       type: none
       o: bind
       device: ./data/lnd2
+  nginx-data:
+    name: boltz-nginx-data
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ./data/backend-nginx/


### PR DESCRIPTION
Needed because the WebSocket is now served on a different port then the rest of the API

Depends on: https://github.com/BoltzExchange/boltz-backend/pull/642