### PR TITLE
chore: add docker-compose.override.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ data/bitcoind/*
 !data/bitcoind/.gitkeep
 data/boltz-client/*
 !data/boltz-client/boltz.toml
+docker-compose.override.yml


### PR DESCRIPTION
For example: https://github.com/BoltzExchange/boltz-client/pull/253