### PR TITLE
Hide original boltz backend nginx headers

### DIFF
--- a/data/backend-nginx/default.conf
+++ b/data/backend-nginx/default.conf
@@ -3,6 +3,10 @@ server {
     listen [::]:9001;
     server_name localhost;
 
+    proxy_hide_header Access-Control-Allow-Origin;
+    proxy_hide_header Access-Control-Allow-Methods;
+    proxy_hide_header Access-Control-Allow-Headers;
+
     add_header Access-Control-Allow-Origin "*" always;
     add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS' always;
     add_header Access-Control-Allow-Headers "*" always;


### PR DESCRIPTION
When accessing the boltz backend from the browser (using rust wasm), requests fail due to `CORS Multiple Origin Not Allowed`.

This PR proposes hiding the original headers set by the boltz backend service so that there are no duplicates caused by nginx adding new ones.