### PR TITLE
feat: BOLT12 reverse swaps

### DIFF
--- a/data/backend/boltz.conf
+++ b/data/backend/boltz.conf
@@ -36,6 +36,7 @@ maxSwapAmount = 40_294_967
 minSwapAmount = 50_000
 
   [pairs.timeoutDelta]
+  chain = 1440
   reverse = 1440
   swapMinimal = 1440
   swapMaximal = 2880
@@ -51,6 +52,7 @@ maxSwapAmount = 40_294_967
 minSwapAmount = 50_000
 
   [pairs.timeoutDelta]
+  chain = 1440
   reverse = 1440
   swapMinimal = 1440
   swapMaximal = 2880
@@ -67,6 +69,7 @@ maxSwapAmount = 4_294_967
 minSwapAmount = 50_000
 
   [pairs.timeoutDelta]
+  chain= 1440
   reverse = 1440
   swapMinimal = 1440
   swapMaximal = 2880
@@ -91,6 +94,7 @@ swapTypes = ["chain"]
   minSwapAmount = 25_000
 
   [pairs.timeoutDelta]
+  chain= 1440
   reverse = 1440
   swapMinimal = 1440
   swapMaximal = 2880

--- a/images/c-lightning-plugins/Dockerfile
+++ b/images/c-lightning-plugins/Dockerfile
@@ -1,23 +1,38 @@
 ARG VERSION=latest
 
+FROM ubuntu:22.04 AS build
+
+RUN apt-get update && apt-get -y upgrade
+RUN apt-get -y install \
+    gcc \
+    git \
+    curl \
+    libpq-dev \
+    libsqlite3-dev \
+    protobuf-compiler
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN git clone https://github.com/BoltzExchange/hold.git
+
+WORKDIR /hold
+RUN git checkout 10c572a8abea39c73bf3323fbb5fa4739ca52279
+RUN cargo build --release
+
 FROM boltz/c-lightning:${VERSION} AS builder
 
 RUN apt-get update && apt-get install -y git pkg-config wget
 
-WORKDIR /hold
-
-# TODO: download arm artifacts
-RUN wget https://github.com/BoltzExchange/hold/releases/download/v0.2.0/hold-linux-amd64.tar.gz
-RUN tar -xvf hold-linux-amd64.tar.gz
-
 WORKDIR /clnurl
 
+# TODO: download arm artifacts
 RUN wget https://github.com/michael1011/clnurl/releases/download/v0.1.0/clnurl.tar.gz
 RUN tar -xvf clnurl.tar.gz
 
 FROM boltz/c-lightning:${VERSION}
 
-COPY --from=builder /hold/build/hold-linux-amd64 /root/hold
+COPY --from=build /hold/target/release/hold /root/hold
 COPY --from=builder /clnurl/clnurl /root/clnurl
 
 ENTRYPOINT ["lightningd"]

--- a/images/scripts/utils.sh
+++ b/images/scripts/utils.sh
@@ -93,7 +93,16 @@ bitcoind-init() {
   bitcoin-cli-sim-server -rpcwallet=regtest -generate 1
 }
 
+# Needed for hold plugin to get the hooks first
+restart_offer_plugin() {
+    lightning-cli-sim $1 plugin stop /usr/libexec/c-lightning/plugins/offers
+    lightning-cli-sim $1 plugin start /usr/libexec/c-lightning/plugins/offers
+}
+
 regtest-start(){
+  restart_offer_plugin 1
+  restart_offer_plugin 2
+
   regtest-init
   deploy_contracts
 }


### PR DESCRIPTION
To build the changed images:
```bash
cd images/c-lightning-plugins
docker build -t boltz/c-lightning-plugins:25.02 -t boltz/c-lightning-plugins:latest . --load
cd -
cd images/scripts
docker build -t boltz/scripts:latest -t boltz/scripts:latest --build-arg UBUNTU_VERSION=24.04 . --load
```

Offers from the CLN invoices do not work *yet*