### PR TITLE
chore: add esplora profile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -465,7 +465,7 @@ services:
     ports:
       - 4002:4002
       - 4003:4003
-    profiles: ["default"]
+    profiles: ["default", "esplora"]
 
   otterscan:
     hostname: otterscan


### PR DESCRIPTION
Some CI environments might want esplora to test integrations with it. Could also add it to the `ci` profile directly, but this allows for more control