### PR TITLE
fix: make backend-dev profile wait for regtest-start completion

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -577,6 +577,8 @@ services:
     image: ${ARKD_IMAGE}
     container_name: arkd
     depends_on:
+      regtest-start:
+        condition: service_completed_successfully
       arkd-wallet:
         condition: service_started
     ports:

--- a/stop.sh
+++ b/stop.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -xe
-docker compose down --volumes
+docker compose down --volumes --remove-orphans -t 0


### PR DESCRIPTION
Add regtest-start dependency to arkd so the backend-dev profile waits for full environment initialization.