### PR TITLE
feat: unify lightning cli shortcuts and clearly mark them as client/server

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ docker exec -it boltz-scripts bash
 - bitcoin-cli-sim-server
 - elements-cli-sim-client
 - elements-cli-sim-server
+- lightning-cli-sim-client
+- lightning-cli-sim-server
+- lncli-sim-client
+- lncli-sim-server
 - boltz-client-cli-sim
 - boltz-backend-cli-sim
-- lightning-cli-sim
-- lncli-sim
 
-Since there are two lnd and two cln instances, use `lncli-sim 1` or `lightning-cli-sim 1` to interact with the first instance and `lncli-sim 2` or `lightning-cli-sim 2` to interact with the second.
 
 Or alternatively, you can `source aliases.sh` to have these convenience scripts available on the host machine.
 

--- a/aliases.sh
+++ b/aliases.sh
@@ -24,3 +24,19 @@ lncli-sim() {
 boltz-backend-cli-sim() {
     docker exec -it boltz-backend bash -c "cd /boltz-backend && ./bin/boltz-cli --rpc.certificates /boltz-data/certificates $(printf '%q ' "$@")"
 }
+
+lightning-cli-sim-client() {
+    run_in_container lightning-cli-sim 1 "$@"
+}
+
+lightning-cli-sim-server() {
+    run_in_container lightning-cli-sim 2 "$@"
+}
+
+lncli-sim-client() {
+    run_in_container lncli-sim 1 "$@"
+}
+
+lncli-sim-server() {
+    run_in_container lncli-sim 2 "$@"
+}

--- a/data/boltz-client/boltz.toml
+++ b/data/boltz-client/boltz.toml
@@ -14,7 +14,7 @@ url = "http://boltz-nginx:9001"
 # path = "/home/michael/test.db"
 
 [CLN]
-host = "cln-2"
+host = "cln-1"
 port = 9736
 
 rootcert = "/root/.lightning/regtest/ca.pem"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,7 +222,7 @@ services:
       retries: 10
       start_period: 0s
     volumes:
-      - cln2-data:/root/.lightning
+      - cln1-data:/root/.lightning
       - elements-data:/root/.elements
       - boltz-client-data:/root/.boltz
     profiles: ['default']

--- a/images/scripts/utils.sh
+++ b/images/scripts/utils.sh
@@ -49,6 +49,23 @@ lncli-sim() {
   lncli --network regtest --rpcserver=lnd-$i:10009 --lnddir=/root/.lnd-"$i" "$@"
 }
 
+# client/backend convenience wrappers
+lightning-cli-sim-client() {
+  lightning-cli-sim 1 "$@"
+}
+
+lightning-cli-sim-server() {
+  lightning-cli-sim 2 "$@"
+}
+
+lncli-sim-client() {
+  lncli-sim 1 "$@"
+}
+
+lncli-sim-server() {
+  lncli-sim 2 "$@"
+}
+
 arkd-sim() {
   arkd --url http://arkd:7071 "$@"
 }


### PR DESCRIPTION
Didn't find first/second very useful. And since bitcoin/elements is already marked as client/server we should mark the lightning nodes as such too. Kept things backwards compatible.

Boltz Client was configured to use `cln-2`, which is used by backend and doesn't make sense to me. So I switched it to have a clear 1= client and 2=server separation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four CLI wrapper commands to run Lightning and LN simulators in distinct client and server modes for finer control of simulator instances.

* **Configuration**
  * Switched the Boltz client to use an alternate CLN node instance and updated the associated Docker volume mount for its data directory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->