### PR TITLE
refactor: expose boltz-client on non-default ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,8 +215,8 @@ services:
     restart: always
     image: ${BOLTZ_CLIENT_IMAGE}
     ports:
-      - 9002:9002
-      - 9003:9003
+      - 9102:9002
+      - 9103:9003
     healthcheck:
       test: ['CMD', 'boltzcli', '--host', 'boltz-client', 'getinfo']
       interval: 5s


### PR DESCRIPTION
this way one can still run the un-changed ci env and a host-level
boltz-client at the same time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service port mappings for deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->