### PR TITLE
fix: backend cli alias

### DIFF
--- a/aliases.sh
+++ b/aliases.sh
@@ -22,7 +22,7 @@ lncli-sim() {
 }
 
 boltz-backend-cli-sim() {
-    docker exec -it boltz-backend bash -c "cd /boltz-backend && ./bin/boltz-cli --rpc.certificates /boltz-data/certificates $(printf '%q ' "$@")"
+    docker exec -it boltz-backend bash -c "/boltz-backend/target/release/boltzr-cli --grpc-certificates /boltz-data/certificates $(printf '%q ' "$@")"
 }
 
 lightning-cli-sim-client() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the boltz-backend CLI simulator invocation to use a different binary and revised command-line flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->