### PR TITLE
feat: support OFT transfer simulation

### DIFF
--- a/.env
+++ b/.env
@@ -9,6 +9,7 @@ BOLTZ_WEBAPP_IMAGE=boltz/web-app:latest
 BOLTZ_CLIENT_IMAGE=boltz/boltz-client:latest
 FOUNDRY_IMAGE=boltz/foundry:latest
 GAS_SPONSOR_EMULATOR_IMAGE=boltz/gas-sponsor-emulator:latest
+LAYERZERO_OFT_IMAGE=boltz/layerzero-oft:latest
 # Default to a public archive RPC so anvil-arb always forks (the backend's
 # Arbitrum config points at real on-chain contracts). Override with your own
 # archive endpoint (e.g. Alchemy) for reliability/rate limits.

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ data/bitcoind/*
 !data/bitcoind/.gitkeep
 data/boltz-client/*
 !data/boltz-client/boltz.toml
+data/layerzero-oft/*
+!data/layerzero-oft/.gitkeep
 docker-compose.override.yml
 data/arkd/*
 !data/arkd/.gitkeep

--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ When using OrbStack on macOS, set `export DOCKER_DEFAULT_PLATFORM=linux/amd64` b
 
 Data dirs for the services are stored in `./data` folder.
 
+### Stablecoin OFT regtest
+
+The Arbitrum CI profiles start a plain Anvil chain and deploy a local LayerZero
+V2 OFT mesh with the official `EndpointV2Mock` testing endpoint. The deployment
+command writes the deployed addresses to `./data/layerzero-oft/deployment.json`
+for the webapp e2e tests.
+
+```bash
+python3 build.py build layerzero-oft
+COMPOSE_PROFILES=webapp-ci ./start.sh
+```
+
+The default profile is unchanged.
+
 ### Scripts container
 
 ```bash

--- a/build.py
+++ b/build.py
@@ -97,6 +97,10 @@ IMAGES: dict[str, Image] = {
         tag="latest",
         arguments=[],
     ),
+    "layerzero-oft": Image(
+        tag="latest",
+        arguments=[],
+    ),
     "scripts": Image(
         tag="latest",
         arguments=[

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ x-services:
       - boltz-data:/root/.boltz-backend:z
       - arkd-data:/root/.arkd:z
       - fulmine-data:/root/.fulmine:z
+      - ./data/layerzero-oft:/root/.layerzero-oft:z
 
   base-lnd: &base-lnd
     image: ${LND_IMAGE}
@@ -307,6 +308,30 @@ services:
       EXTRA_ANVIL_ARGS: '--gas-limit 30000000'
     ports:
       - ${ARBITRUM_E2E_PORT:-18545}:8545
+    profiles: ['ci', 'webapp-ci']
+
+  anvil-oft:
+    <<: *base-anvil
+    hostname: anvil-oft
+    container_name: anvil-oft
+    environment:
+      CHAIN_ID: 31337
+    ports:
+      - ${LAYERZERO_OFT_PORT:-18548}:8545
+    profiles: ['ci', 'webapp-ci']
+
+  layerzero-oft:
+    hostname: layerzero-oft
+    container_name: layerzero-oft
+    image: ${LAYERZERO_OFT_IMAGE}
+    environment:
+      LAYERZERO_OFT_RPC_URL: http://anvil-oft:8545
+      LAYERZERO_OFT_OUTPUT_DIR: /data/layerzero-oft
+    depends_on:
+      anvil-oft:
+        condition: service_healthy
+    volumes:
+      - ./data/layerzero-oft:/data/layerzero-oft:z
     profiles: ['ci', 'webapp-ci']
 
   gas-sponsor-emulator:

--- a/images/layerzero-oft/Dockerfile
+++ b/images/layerzero-oft/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-bookworm-slim
+
+WORKDIR /app
+
+COPY package.json package.json
+RUN npm install --no-audit --no-fund
+
+COPY contracts contracts
+COPY hardhat.config.js hardhat.config.js
+COPY scripts scripts
+
+RUN npx hardhat compile
+
+ENTRYPOINT ["npx", "hardhat", "run", "--network", "regtest", "/app/scripts/deploy.js"]

--- a/images/layerzero-oft/contracts/RegtestOFT.sol
+++ b/images/layerzero-oft/contracts/RegtestOFT.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { OFT } from "@layerzerolabs/oft-evm/contracts/OFT.sol";
+
+// Compile the mock endpoint artifact used by the deployment script.
+import "@layerzerolabs/test-devtools-evm-hardhat/contracts/mocks/EndpointV2Mock.sol";
+
+contract RegtestOFT is OFT {
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        address endpoint_,
+        address delegate_
+    ) OFT(name_, symbol_, endpoint_, delegate_) Ownable(delegate_) {}
+
+    function mint(address to, uint256 amount) external onlyOwner {
+        _mint(to, amount);
+    }
+}

--- a/images/layerzero-oft/hardhat.config.js
+++ b/images/layerzero-oft/hardhat.config.js
@@ -1,0 +1,22 @@
+require("@nomiclabs/hardhat-ethers");
+
+module.exports = {
+    solidity: {
+        version: "0.8.22",
+        settings: {
+            optimizer: {
+                enabled: true,
+                runs: 200,
+            },
+        },
+    },
+    networks: {
+        regtest: {
+            url: process.env.LAYERZERO_OFT_RPC_URL || "http://anvil-oft:8545",
+            accounts: [
+                process.env.LAYERZERO_OFT_DEPLOYER_KEY ||
+                    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+            ],
+        },
+    },
+};

--- a/images/layerzero-oft/package.json
+++ b/images/layerzero-oft/package.json
@@ -1,0 +1,18 @@
+{
+    "scripts": {
+        "compile": "hardhat compile"
+    },
+    "dependencies": {
+        "@layerzerolabs/lz-evm-messagelib-v2": "3.0.168",
+        "@layerzerolabs/lz-evm-protocol-v2": "3.0.168",
+        "@layerzerolabs/lz-v2-utilities": "3.0.168",
+        "@layerzerolabs/oapp-evm": "0.4.1",
+        "@layerzerolabs/oft-evm": "4.0.1",
+        "@layerzerolabs/test-devtools-evm-hardhat": "0.5.3",
+        "@nomiclabs/hardhat-ethers": "2.2.3",
+        "@openzeppelin/contracts": "5.6.1",
+        "@openzeppelin/contracts-upgradeable": "5.6.1",
+        "ethers": "5.7.2",
+        "hardhat": "2.22.19"
+    }
+}

--- a/images/layerzero-oft/scripts/deploy.js
+++ b/images/layerzero-oft/scripts/deploy.js
@@ -1,0 +1,184 @@
+const fs = require("fs");
+const path = require("path");
+
+const { Options } = require("@layerzerolabs/lz-v2-utilities");
+const hre = require("hardhat");
+
+const MSG_TYPE_SEND = 1;
+const OUTPUT_FILE = "deployment.json";
+
+const readPositiveInteger = (name, fallback) => {
+    const rawValue = process.env[name];
+    const value = Number(
+        rawValue === undefined || rawValue === "" ? fallback : rawValue,
+    );
+
+    if (!Number.isSafeInteger(value) || value <= 0) {
+        throw new Error(`${name} must be a positive integer`);
+    }
+
+    return value;
+};
+
+const readTokenAmount = (name, fallback) => {
+    const rawValue = process.env[name];
+    const value = rawValue === undefined || rawValue === "" ? fallback : rawValue;
+
+    return hre.ethers.utils.parseUnits(value, 18);
+};
+
+const config = {
+    sourceEid: readPositiveInteger("LAYERZERO_OFT_SOURCE_EID", 40231),
+    destinationEid: readPositiveInteger("LAYERZERO_OFT_DESTINATION_EID", 40232),
+    outputDir: process.env.LAYERZERO_OFT_OUTPUT_DIR || "/data/layerzero-oft",
+    initialBalance: readTokenAmount("LAYERZERO_OFT_INITIAL_BALANCE", "1000"),
+    lzReceiveGas: readPositiveInteger("LAYERZERO_OFT_LZ_RECEIVE_GAS", 65000),
+};
+
+if (config.sourceEid === config.destinationEid) {
+    throw new Error("source and destination EIDs must be different");
+}
+
+const outputPath = path.join(config.outputDir, OUTPUT_FILE);
+const temporaryOutputPath = `${outputPath}.tmp`;
+
+const wait = async (txPromise) => {
+    const tx = await txPromise;
+    return tx.wait();
+};
+
+const toBytes32Address = (address) =>
+    hre.ethers.utils.hexZeroPad(hre.ethers.utils.getAddress(address), 32);
+
+async function deployEndpoint(deployer, eid) {
+    const factory = await hre.ethers.getContractFactory(
+        "EndpointV2Mock",
+        deployer,
+    );
+    const endpoint = await factory.deploy(eid);
+    await endpoint.deployed();
+    return endpoint;
+}
+
+async function deployOft(endpoint, deployer, suffix) {
+    const factory = await hre.ethers.getContractFactory("RegtestOFT", deployer);
+    const oft = await factory.deploy(
+        `Regtest USDT0 ${suffix}`,
+        "USDT0",
+        endpoint.address,
+        deployer.address,
+    );
+    await oft.deployed();
+    return oft;
+}
+
+async function deploySide(deployer, name, eid) {
+    const endpoint = await deployEndpoint(deployer, eid);
+    const oft = await deployOft(endpoint, deployer, name);
+
+    return {
+        eid,
+        endpoint,
+        oft,
+    };
+}
+
+async function connectRoute(from, to, options) {
+    await wait(
+        from.endpoint.setDestLzEndpoint(to.oft.address, to.endpoint.address),
+    );
+    await wait(from.oft.setPeer(to.eid, toBytes32Address(to.oft.address)));
+    await wait(
+        from.oft.setEnforcedOptions([
+            {
+                eid: to.eid,
+                msgType: MSG_TYPE_SEND,
+                options,
+            },
+        ]),
+    );
+}
+
+async function writeDeploymentFile(deployment) {
+    fs.mkdirSync(config.outputDir, { recursive: true });
+    fs.writeFileSync(
+        temporaryOutputPath,
+        `${JSON.stringify(deployment, null, 2)}\n`,
+    );
+    fs.renameSync(temporaryOutputPath, outputPath);
+}
+
+function removeStaleDeploymentFile() {
+    fs.rmSync(outputPath, { force: true });
+    fs.rmSync(temporaryOutputPath, { force: true });
+}
+
+function deploymentJson({
+    network,
+    deployerAddress,
+    source,
+    destination,
+    options,
+}) {
+    return {
+        network: {
+            name: network.name,
+            chainId: network.chainId,
+        },
+        deployer: deployerAddress,
+        eids: {
+            source: source.eid,
+            destination: destination.eid,
+        },
+        endpoints: {
+            source: source.endpoint.address,
+            destination: destination.endpoint.address,
+        },
+        oft: {
+            source: source.oft.address,
+            destination: destination.oft.address,
+        },
+        enforcedOptions: {
+            msgTypeSend: MSG_TYPE_SEND,
+            lzReceiveGas: config.lzReceiveGas,
+            options,
+        },
+    };
+}
+
+async function main() {
+    const [deployer] = await hre.ethers.getSigners();
+
+    removeStaleDeploymentFile();
+
+    const source = await deploySide(deployer, "Source", config.sourceEid);
+    const destination = await deploySide(
+        deployer,
+        "Destination",
+        config.destinationEid,
+    );
+
+    const lzReceiveOptions = Options.newOptions()
+        .addExecutorLzReceiveOption(config.lzReceiveGas, 0)
+        .toHex();
+
+    await connectRoute(source, destination, lzReceiveOptions);
+    await connectRoute(destination, source, lzReceiveOptions);
+    await wait(source.oft.mint(deployer.address, config.initialBalance));
+
+    const deployment = deploymentJson({
+        network: await hre.ethers.provider.getNetwork(),
+        deployerAddress: deployer.address,
+        source,
+        destination,
+        options: lzReceiveOptions,
+    });
+
+    await writeDeploymentFile(deployment);
+    console.log(JSON.stringify(deployment, null, 2));
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/images/scripts/cleanup.sh
+++ b/images/scripts/cleanup.sh
@@ -32,6 +32,7 @@ WIPE_DIRS=(
     ".boltz-client"
     ".arkd"
     ".fulmine"
+    ".layerzero-oft"
 )
 
 for dir in "${WIPE_DIRS[@]}"; do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional “stablecoins” regtest profile that starts a local LayerZero OFT setup alongside Anvil.
  * Added support for deploying a local token mesh and generating deployment data for tests and local workflows.
  * Included a new image and runtime configuration for the LayerZero OFT environment.

* **Documentation**
  * Expanded the README with setup and run instructions for the new profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->